### PR TITLE
Update comparison signals of electric machine examples in v323+build.4

### DIFF
--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Conveyor/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Conveyor/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_DOL/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_DOL/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Initialize/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Initialize/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Inverter/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Inverter/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_InverterDrive/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_InverterDrive/comparisonSignals.txt
@@ -1,9 +1,11 @@
 time
-aimc.i_0_s
+// aimc.i_0_s
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]
 aimc.idq_sr[2]
+aimc.is[1]
+aimc.is[2]
 capacitor.v
 inductor.inductor[2].i
 inductor.inductor[3].i

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Steinmetz/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Steinmetz/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Transformer/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_Transformer/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_YD/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_YD/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_withLosses/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMC_withLosses/comparisonSignals.txt
@@ -1,5 +1,7 @@
 time
 PI.x
+aimc.is[1]
+aimc.is[2]
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMS_Start/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/AsynchronousInductionMachines/AIMS_Start/comparisonSignals.txt
@@ -1,7 +1,11 @@
 time
-aims.i_0_r
+// aims.i_0_r
+aimc.ir[1]
+aimc.ir[2]
 aims.idq_rr[1]
 aims.idq_rr[2]
+aimc.is[1]
+aimc.is[2]
 aims.idq_sr[1]
 aims.idq_sr[2]
 loadInertia.phi

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_DOL/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_DOL/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+smee.is[1]
+smee.is[2]
 smee.idq_dr[1]
 smee.idq_rr[2]
 smee.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_Generator/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_Generator/comparisonSignals.txt
@@ -1,5 +1,7 @@
 time
 constantSpeed.phi
+smee.is[1]
+smee.is[2]
 smee.idq_dr[1]
 smee.idq_rr[2]
 smee.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_LoadDump/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_LoadDump/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+smee.is[1]
+smee.is[2]
 smee.idq_dr[1]
 smee.idq_rr[2]
 smee.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_Rectifier/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMEE_Rectifier/comparisonSignals.txt
@@ -3,6 +3,8 @@ capacitor1.v
 capacitor2.v
 filter.x[1]
 filter.x[2]
+smee.is[1]
+smee.is[2]
 smee.idq_dr[1]
 smee.idq_rr[2]
 smee.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_Braking/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_Braking/comparisonSignals.txt
@@ -1,5 +1,7 @@
 time
 inertiaLoad.phi
 inertiaLoad.w
+smee.is[1]
+smee.is[2]
 smpm.idq_sr[1]
 smpm.idq_sr[2]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_CurrentSource/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_CurrentSource/comparisonSignals.txt
@@ -1,3 +1,5 @@
 time
+smee.is[1]
+smee.is[2]
 inertiaLoad.w
 speedSensor.flange.phi

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_Inverter/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_Inverter/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 loadInertia.phi
 loadInertia.w
+smee.is[1]
+smee.is[2]
 smpm.idq_dr[1]
 smpm.idq_rr[2]
 smpm.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_NoLoad/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_NoLoad/comparisonSignals.txt
@@ -1,2 +1,4 @@
 time
+smee.is[1]
+smee.is[2]
 constantSpeed.phi

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_VoltageSource/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMPM_VoltageSource/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 inertiaLoad.phi
 inertiaLoad.w
+smee.is[1]
+smee.is[2]
 smpm.idq_sr[1]
 smpm.idq_sr[2]
 voltageController.PI_d.x

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMR_DOL/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMR_DOL/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 loadInertia.phi
 loadInertia.w
+smee.is[1]
+smee.is[2]
 smr.idq_rr[1]
 smr.idq_rr[2]
 smr.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMR_Inverter/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/SynchronousInductionMachines/SMR_Inverter/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 loadInertia.phi
 loadInertia.w
+smee.is[1]
+smee.is[2]
 smr.idq_rr[1]
 smr.idq_rr[2]
 smr.idq_sr[1]

--- a/Modelica/Electrical/Machines/Examples/Transformers/AIMC_Transformer/comparisonSignals.txt
+++ b/Modelica/Electrical/Machines/Examples/Transformers/AIMC_Transformer/comparisonSignals.txt
@@ -1,9 +1,11 @@
 time
-aimc.i_0_s
+// aimc.i_0_s
 aimc.idq_rr[1]
 aimc.idq_rr[2]
 aimc.idq_sr[1]
 aimc.idq_sr[2]
+smee.is[1]
+smee.is[2]
 loadInertia.phi
 loadInertia.w
 transformer.l2sigma.inductor[2].i

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Conveyor/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Conveyor/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_DOL/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_DOL/comparisonSignals.txt
@@ -1,14 +1,18 @@
 time
-aimcE.i_0_s
+// aimcE.i_0_s
 aimcE.idq_rr[1]
 aimcE.idq_rr[2]
 aimcE.idq_sr[1]
 aimcE.idq_sr[2]
+aimcE.is[1]
+aimcE.is[2]
 aimcM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimcM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimcM.stator.strayReluctance.port_p.Phi.im
 aimcM.stator.strayReluctance.port_p.Phi.re
-aimcM.stator.zeroInductor.i0
+// aimcM.stator.zeroInductor.i0
+aimcM.is[1]
+aimcM.is[2]
 loadInertiaE.phi
 loadInertiaE.w
 loadInertiaM.phi

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_DOL_MultiPhase/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_DOL_MultiPhase/comparisonSignals.txt
@@ -1,8 +1,14 @@
 time
+aimc3.is[1]
+aimc3.is[2]
 aimc3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc3.stator.strayReluctance.port_p.Phi.im
 aimc3.stator.strayReluctance.port_p.Phi.re
+aimcM.is[1]
+aimcM.is[2]
+aimcM.is[3]
+aimcM.is[4]
 aimcM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimcM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimcM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Initialize/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Initialize/comparisonSignals.txt
@@ -9,6 +9,8 @@ aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.strayReluctance.port_p.Phi.im
 aimc.stator.strayReluctance.port_p.Phi.re
-aimc.stator.zeroInductor.i0
+// aimc.stator.zeroInductor.i0
+aimc.is[1]
+aimc.is[2]
 loadInertia.phi
 loadInertia.w

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Inverter/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Inverter/comparisonSignals.txt
@@ -1,4 +1,6 @@
 time
+aimc.is[1]
+aimc.is[2]
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Steinmetz/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Steinmetz/comparisonSignals.txt
@@ -3,7 +3,9 @@ aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].P
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimc.stator.zeroInductor.i0
+// aimc.stator.zeroInductor.i0
+aimc.is[1]
+aimc.is[2]
 cRun.v
 cStart.v
 loadInertia.phi

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Transformer/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_Transformer/comparisonSignals.txt
@@ -3,7 +3,9 @@ aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].P
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimc.stator.zeroInductor.i0
+// aimc.stator.zeroInductor.i0
+aimc.is[1]
+aimc.is[2]
 loadInertia.phi
 loadInertia.w
 transformer.l2sigma.inductor[1].i

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_YD/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_YD/comparisonSignals.txt
@@ -3,6 +3,8 @@ aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].P
 aimc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimc.stator.zeroInductor.i0
+// aimc.stator.zeroInductor.i0
+aimc.is[1]
+aimc.is[2]
 loadInertia.phi
 loadInertia.w

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_withLosses/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMC_withLosses/comparisonSignals.txt
@@ -10,6 +10,8 @@ aimc.stator.core.Phi.im
 aimc.stator.core.Phi.re
 aimc.stator.strayReluctance.port_p.Phi.im
 aimc.stator.strayReluctance.port_p.Phi.re
-aimc.stator.zeroInductor.i0
+// aimc.stator.zeroInductor.i0
+aimc.is[1]
+aimc.is[2]
 loadInertia.w
 powerSensor.flange_a.phi

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMS_Start/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMS_Start/comparisonSignals.txt
@@ -1,16 +1,24 @@
 time
-aimsE.i_0_r
-aimsE.i_0_s
+// aimsE.i_0_r
+// aimsE.i_0_s
 aimsE.idq_rr[1]
 aimsE.idq_rr[2]
 aimsE.idq_sr[1]
 aimsE.idq_sr[2]
+aimsE.is[1]
+aimsE.is[2]
+aimsE.ir[1]
+aimsE.ir[2]
 aimsM.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimsM.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimsM.rotor.zeroInductor.i0
+// aimsM.rotor.zeroInductor.i0
+aimsM.is[1]
+aimsM.is[2]
+aimsM.ir[1]
+aimsM.ir[2]
 aimsM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimsM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimsM.stator.zeroInductor.i0
+// aimsM.stator.zeroInductor.i0
 loadInertiaE.phi
 loadInertiaE.w
 loadInertiaM.phi

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMS_Start_MultiPhase/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/AIMS_Start_MultiPhase/comparisonSignals.txt
@@ -1,12 +1,18 @@
 time
+aimc3.is[1]
+aimc3.is[2]
 aims3.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aims3.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aims3.rotor.zeroInductor.i0
+// aims3.rotor.zeroInductor.i0
 aims3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aims3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
+aimcM.is[1]
+aimcM.is[2]
+aimcM.is[3]
+aimcM.is[4]
 aimsM.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimsM.rotor.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-aimsM.rotor.zeroInductor.i0
+// aimsM.rotor.zeroInductor.i0
 aimsM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 aimsM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 loadInertia3.phi

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_DOL/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_DOL/comparisonSignals.txt
@@ -2,6 +2,8 @@ time
 smee.excitation.electroMagneticConverter.Phi.re
 smee.inertiaRotor.phi
 smee.inertiaRotor.w
+smee.is[1]
+smee.is[2]
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smee.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Generator/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Generator/comparisonSignals.txt
@@ -1,10 +1,14 @@
 time
 constantSpeedE.phi
 constantSpeedM.phi
+smeeE.is[1]
+smeeE.is[2]
 smeeE.idq_dr[1]
 smeeE.idq_rr[2]
 smeeE.idq_sr[1]
 smeeE.idq_sr[2]
+smeeM.is[1]
+smeeM.is[2]
 smeeM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smeeM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smeeM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Generator_MultiPhase/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Generator_MultiPhase/comparisonSignals.txt
@@ -1,10 +1,16 @@
 time
 constantSpeed3.phi
 constantSpeedM.phi
+smee3.is[1]
+smee3.is[2]
 smee3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smee3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smee3.stator.strayReluctance.port_p.Phi.im
 smee3.stator.strayReluctance.port_p.Phi.re
+smeeM.is[1]
+smeeM.is[2]
+smeeM.is[3]
+smeeM.is[4]
 smeeM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smeeM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smeeM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_LoadDump/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_LoadDump/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 loadInductor.inductor[2].i
 loadInductor.inductor[3].i
+smee.is[1]
+smee.is[2]
 smee.excitation.electroMagneticConverter.Phi.re
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Rectifier/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMEE_Rectifier/comparisonSignals.txt
@@ -3,6 +3,8 @@ capacitor1.v
 capacitor2.v
 filter.x[1]
 filter.x[2]
+smee.is[1]
+smee.is[2]
 smee.excitation.electroMagneticConverter.Phi.re
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smee.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Braking/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Braking/comparisonSignals.txt
@@ -3,4 +3,6 @@ inertiaLoad.phi
 inertiaLoad.w
 smpm.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smpm.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-smpm.stator.zeroInductor.i0
+// smpm.stator.zeroInductor.i0
+smpm.is[1]
+smpm.is[2]

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_CurrentSource/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_CurrentSource/comparisonSignals.txt
@@ -1,3 +1,5 @@
 time
 inertiaLoad.w
 speedSensor.flange.phi
+smpm.is[1]
+smpm.is[2]

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Inverter/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Inverter/comparisonSignals.txt
@@ -3,10 +3,14 @@ loadInertiaE.phi
 loadInertiaE.w
 loadInertiaM.phi
 loadInertiaM.w
+smpmE.is[1]
+smpmE.is[2]
 smpmE.idq_dr[1]
 smpmE.idq_rr[2]
 smpmE.idq_sr[1]
 smpmE.idq_sr[2]
+smpmM.is[1]
+smpmM.is[2]
 smpmM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smpmM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smpmM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Inverter_MultiPhase/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_Inverter_MultiPhase/comparisonSignals.txt
@@ -3,10 +3,16 @@ loadInertia3.phi
 loadInertia3.w
 loadInertiaM.phi
 loadInertiaM.w
+smpm3.is[1]
+smpm3.is[2]
 smpm3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smpm3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smpm3.stator.strayReluctance.port_p.Phi.im
 smpm3.stator.strayReluctance.port_p.Phi.re
+smpmM.is[1]
+smpmM.is[2]
+smpmM.is[3]
+smpmM.is[4]
 smpmM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smpmM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smpmM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_VoltageSource/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMPM_VoltageSource/comparisonSignals.txt
@@ -1,6 +1,8 @@
 time
 inertiaLoad.phi
 inertiaLoad.w
+smpm.is[1]
+smpm.is[2]
 smpm.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smpm.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 voltageController.PI_d.x

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMR_Inverter/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMR_Inverter/comparisonSignals.txt
@@ -3,10 +3,14 @@ loadInertiaE.phi
 loadInertiaE.w
 loadInertiaM.phi
 loadInertiaM.w
+smrE.is[1]
+smrE.is[2]
 smrE.idq_rr[1]
 smrE.idq_rr[2]
 smrE.idq_sr[1]
 smrE.idq_sr[2]
+smrM.is[1]
+smrM.is[2]
 smrM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smrM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smrM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMR_Inverter_MultiPhase/comparisonSignals.txt
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SMR_Inverter_MultiPhase/comparisonSignals.txt
@@ -3,10 +3,14 @@ loadInertia3.phi
 loadInertia3.w
 loadInertiaM.phi
 loadInertiaM.w
+smr3.is[1]
+smr3.is[2]
 smr3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smr3.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smr3.stator.strayReluctance.port_p.Phi.im
 smr3.stator.strayReluctance.port_p.Phi.re
+smrM.is[1]
+smrM.is[2]
 smrM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 smrM.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 smrM.stator.strayReluctance.port_p.Phi.im

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/comparisonSignals.txt
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/comparisonSignals.txt
@@ -3,7 +3,7 @@ imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Ph
 imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-imc.stator.zeroInductor.i0
+// imc.stator.zeroInductor.i0
 imcQS.rotorCage.port_p.reference.gamma
 mass.s
 mass.v

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize/comparisonSignals.txt
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize/comparisonSignals.txt
@@ -9,7 +9,7 @@ imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.r
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 imc.stator.strayReluctance.port_p.Phi.im
 imc.stator.strayReluctance.port_p.Phi.re
-imc.stator.zeroInductor.i0
+// imc.stator.zeroInductor.i0
 imcQS.rotorCage.port_p.reference.gamma
 loadInertia.phi
 loadInertia.w

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer/comparisonSignals.txt
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer/comparisonSignals.txt
@@ -3,7 +3,7 @@ imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Ph
 imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-imc.stator.zeroInductor.i0
+// imc.stator.zeroInductor.i0
 imcQS.rotorCage.port_p.reference.gamma
 loadInertia.phi
 loadInertia.w

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD/comparisonSignals.txt
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD/comparisonSignals.txt
@@ -3,7 +3,7 @@ imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Ph
 imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
 imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-imc.stator.zeroInductor.i0
+// imc.stator.zeroInductor.i0
 imcQS.rotorCage.port_p.reference.gamma
 loadInertia.phi
 loadInertia.w


### PR DESCRIPTION
Refs modelica/ModelicaStandardLibrary#3587

Creating the very same changes as in https://github.com/modelica/ModelicaStandardLibrary/pull/3497/files for MSL 3.2.3:

- Remove zero sequence currents
- Add phase currents instead
- Apply changes to v323+build.4

This PR replaces #2 
